### PR TITLE
Fixed doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,9 @@ __pycache__
 build
 dist
 otbenchmark.egg-info
+.vscode/
+doc/_build/
+doc/auto_examples/
+doc/sg_execution_times.rst
+doc/user_manual/_generated/
 

--- a/README.md
+++ b/README.md
@@ -21,10 +21,29 @@ Most of the reliability problems were adapted from the RPRepo
 
 https://rprepo.readthedocs.io/en/latest/
 
-This module allows you to create a problem, run an algorithm and 
-compare the computed probability with a reference probability: 
+This module makes it possible to create a problem, run an algorithm and 
+compare the computed probability with a reference probability. 
 Moreover, we can loop over all problems and run several methods on these 
 problems.
+
+## Example
+The next example shows how to use the R-S reliability problem.
+```python
+import otbenchmark as otb
+import openturns as ot
+
+problem = otb.RminusSReliability()
+event = problem.getEvent()
+reference_pf = problem.getProbability() # exact probability
+# Create the Monte-Carlo algorithm
+algoProb = ot.ProbabilitySimulationAlgorithm(event)
+algoProb.setMaximumOuterSampling(1000)
+algoProb.setMaximumCoefficientOfVariation(0.01)
+algoProb.run()
+resultAlgo = algoProb.getResult()
+computed_pf = resultAlgo.getProbabilityEstimate()
+absoluteError = abs(computed_pf - reference_pf)
+```
 
 ## Authors
 

--- a/doc/examples/reliability_methods/plot_new_reliability_problem.py
+++ b/doc/examples/reliability_methods/plot_new_reliability_problem.py
@@ -1,0 +1,121 @@
+"""
+Create a new reliability problem
+================================
+"""
+
+# %%
+# The objective of this example is to create a new reliability
+# problem.
+# This can be useful when we want to consider a new problem which is
+# not already available in the benchmark.
+# This makes it possible to consider a new problem as if it was in the
+# package.
+
+# %%
+import openturns as ot
+import openturns.viewer as otv
+import otbenchmark as otb
+import numpy as np
+
+
+# %%
+# In order to create our own benchmark problem, we must
+# create a new class which derives from ReliabilityBenchmarkProblem.
+class OscillatorProblem(otb.ReliabilityBenchmarkProblem):
+    def __init__(self):
+        """Create the Oscillator problem
+
+        This is a two-degree-of-freedom damped oscillator with primary
+        and secondary systems.
+
+        Reference
+        ---------
+        - "Analyse de sensibilité fiabiliste avec prise en compte d'incertitudes
+          sur le modèle probabiliste", Vincent Chabridon. Thèse. 2018, pp.91-92.
+        - De Stefano M., Der Kiureghian A. (1990). An efficient algorithm for
+          second-order reliability analysis.
+          Report No. UCB/SEMM-90/20. Dept of Civil and Environmental Engineering,
+          University of California, Berkeley.
+        """
+
+        def oscillator(x):
+            mp, ms, kp, ks, xip, xis, S0 = x
+            omega_p = np.sqrt(kp / mp)
+            omega_s = np.sqrt(ks / ms)
+            gamma = ms / mp
+            omega_a = 0.5 * (omega_p + omega_s)
+            xi_a = 0.5 * (xip + xis)
+            theta = 1.0 / omega_a * (omega_p - omega_s)
+            factor_1 = np.pi * S0 / (4.0 * xis * omega_s**3)
+            factor_2 = (
+                xi_a * xis / (xip * xis * (4.0 * xi_a**2 + theta**2) + gamma * xi_a**2)
+            )
+            factor_3 = (
+                (xip * omega_p**3 + xis * omega_s**3)
+                * omega_p
+                / (4.0 * xi_a * omega_a**4)
+            )
+            F = 3 * ks * np.sqrt(factor_1 * factor_2 * factor_3)
+            return [F]
+
+        name = "Oscillator"
+        dim = 7
+        limitStateFunction = ot.PythonFunction(dim, 1, oscillator)
+        mean_list = [1.5, 0.01, 1.0, 0.01, 0.05, 0.02, 100.0]
+        cov_list = [0.1, 0.1, 0.2, 0.2, 0.4, 0.5, 0.1]
+        myCollection = ot.DistributionCollection(dim)
+        for i, (mu, cov) in enumerate(zip(mean_list, cov_list)):
+            parameters = ot.LogNormalMuSigma(mu, mu * cov, 0.0)
+            myCollection[i] = ot.ParametrizedDistribution(parameters)
+        distribution = ot.ComposedDistribution(myCollection)
+        inputRandomVector = ot.RandomVector(distribution)
+        outputRandomVector = ot.CompositeRandomVector(
+            limitStateFunction, inputRandomVector
+        )
+        threshold = 0.0
+        thresholdEvent = ot.ThresholdEvent(outputRandomVector, ot.Less(), threshold)
+        probability = 3.78e-7
+        super().__init__(name, thresholdEvent, probability)
+        return None
+
+
+# %%
+problem = OscillatorProblem()
+print(problem)
+
+# %%
+event = problem.getEvent()
+g = event.getFunction()
+
+# %%
+problem.getProbability()
+
+# %%
+# Create the Monte-Carlo algorithm
+algoProb = ot.ProbabilitySimulationAlgorithm(event)
+algoProb.setMaximumOuterSampling(100)
+algoProb.setBlockSize(10)
+algoProb.setMaximumCoefficientOfVariation(0.01)
+algoProb.run()
+
+# %%
+# Get the results
+resultAlgo = algoProb.getResult()
+neval = g.getEvaluationCallsNumber()
+print("Number of function calls = %d" % (neval))
+pf = resultAlgo.getProbabilityEstimate()
+print("Failure Probability = %.4f" % (pf))
+level = 0.95
+c95 = resultAlgo.getConfidenceLength(level)
+pmin = pf - 0.5 * c95
+pmax = pf + 0.5 * c95
+print("%.1f %% confidence interval :[%.4f,%.4f] " % (level * 100, pmin, pmax))
+
+# %%
+# The reference probability is too close to zero: Monte-Carlo sampling cannot
+# achieve a satisfactory accuracy.
+
+# %%
+otv.View.ShowAll()
+
+# %%

--- a/doc/examples/sensitivity_methods/plot_benchmark_sensitivity_methods.py
+++ b/doc/examples/sensitivity_methods/plot_benchmark_sensitivity_methods.py
@@ -152,6 +152,7 @@ print("    T = ", computed_total_order)
 
 # %%
 # We consider the following accuracy metrics:
+#
 # * the vector or log relative errors for a given index (first order or total order),
 # * the mean log relative error, as the mean of the LRE vector (first order or total order),
 # * the average mean log relative error, as the mean of the first and total order mean log relative error.

--- a/doc/math_notations.sty
+++ b/doc/math_notations.sty
@@ -4,6 +4,8 @@
 \usepackage{amsmath}
 \usepackage{amssymb}
 
+\newcommand{\inputDim}{d}  % The input dimension of the model
+
 % For matrixes and vectors
 \newcommand{\vect}[1]{{\underline{#1}}}
 \newcommand{\mat}[1]{{\underline{\underline{#1}}}}
@@ -111,7 +113,7 @@
 \newcommand{\uz}{\underline{z}}
 \newcommand{\uZ}{\underline{Z}}
 \newcommand{\muX}{\underline{\mu}_{\:X}}
-\newcommand{\Var}[1]{{\rm Var}\left[ #1 \right]}
+\newcommand{\Var}[1]{{\rm Var}\left( #1 \right)}
 \newcommand{\Cov}[1]{{\rm Cov}\left[ #1 \right]}
 \newcommand{\Expect}[1]{{\mathbb E}\left[ #1 \right]}
 \newcommand{\Prob}[1]{{\mathbb P}\left[ #1 \right]}

--- a/examples/scripts/test-computeCDF.py
+++ b/examples/scripts/test-computeCDF.py
@@ -13,6 +13,10 @@ def ComputeReferenceProbability(problem, verbose=False):
     """
     Compute the probability of a reliability problem using computeCDF().
 
+    Translate the formula into an string expression, then use
+    distribution arithmetic.
+    This method works only for a limited number of simple reliability problems.
+
     Parameters
     ----------
     problem : ot.ReliabilityProblem

--- a/otbenchmark/ReliabilityLibrary.py
+++ b/otbenchmark/ReliabilityLibrary.py
@@ -1,6 +1,7 @@
 """
 Manage reliability problems.
 """
+
 import otbenchmark as otb
 import numpy as np
 import sys

--- a/otbenchmark/SensitivityLibrary.py
+++ b/otbenchmark/SensitivityLibrary.py
@@ -1,6 +1,7 @@
 """
 Manage sensitivity problems.
 """
+
 import otbenchmark as otb
 
 

--- a/otbenchmark/_AxialStressedBeamReliability.py
+++ b/otbenchmark/_AxialStressedBeamReliability.py
@@ -13,12 +13,15 @@ class AxialStressedBeamReliability(ReliabilityBenchmarkProblem):
         r"""
         Create a axial stressed beam reliability problem.
 
-        The inputs are R, the Yield strength, and F, the traction load.
-        We have R ~ LogNormalMuSigma() and F ~ Normal().
+        The event is :math:`\{g(\boldsymbol{X}) < \text{threshold}\}` where:
 
         .. math::
 
-            g(R, F) = R - \frac{F}{\pi 100}
+            g(R, F) = R - \frac{F}{100 \pi}
+
+        for any value of R and F.
+        The inputs are R, the Yield strength, and F, the traction load.
+        We have R ~ LogNormalMuSigma() and F ~ Normal().
 
         Parameters
         ----------

--- a/otbenchmark/_BoreholeSensitivity.py
+++ b/otbenchmark/_BoreholeSensitivity.py
@@ -11,23 +11,54 @@ class BoreholeSensitivity(SensitivityBenchmarkProblem):
     """Class to define a Borehole sensitivity benchmark problem."""
 
     def __init__(self):
-        """
+        r"""
         Create a Borehole sensitivity problem.
 
         The function is defined by the equation:
 
-        g(x) = (2*pi_*Tu*(Hu-Hl))/(ln(r/rw)*(1+(2*L*Tu)/(ln(r/rw)*rw^2*Kw)+Tu/Tl))
+        .. math::
 
-        where:
+            g(\boldsymbol{x})
+            = \frac{2\pi\, T_u\, (H_u - H_\ell)}{\ln\!\left(\frac{r}{r_w}\right)\left(1 + \frac{2 L T_u}
+                {\ln\!\left(\frac{r}{r_w}\right) r_w^{2} K_w} + \frac{T_u}{T_\ell}\right)}
 
-        * r_w: radius of borehole (m)
-        * r: radius of influence (m)
-        * T_u: transmissivity of upper aquifer (m^2/yr)
-        * H_u: potentiometric head of upper aquifer (m)
-        * T_l: transmissivity of lower aquifer (m^2/yr)
-        * H_l: potentiometric head of lower aquifer (m)
-        * L: length of borehole (m)
-        * K_w: hydraulic conductivity of borehole (m/yr)
+        where :math:`\boldsymbol{x} = (r_w, r, T_u, H_u, T_\ell, H_\ell, L, K_w)^\top`
+        and :
+
+        * :math:`r_w`: radius of borehole (m);
+        * :math:`r`: radius of influence (m);
+        * :math:`T_u`: transmissivity of upper aquifer (m²/yr);
+        * :math:`H_u`: potentiometric head of upper aquifer (m);
+        * :math:`T_\ell`: transmissivity of lower aquifer (m²/yr);
+        * :math:`H_\ell`: potentiometric head of lower aquifer (m);
+        * :math:`L`: length of borehole (m);
+        * :math:`K_w`: hydraulic conductivity of borehole (m/yr).
+
+        The next table presents the marginal distributions of
+        each random variable in the model.
+
+        .. table::
+            :widths: auto
+
+            +---------------+-------------+------------------------------------------+
+            | Variable      | Distribution| Parameters                               |
+            +===============+=============+==========================================+
+            | :math:`r_w`   | Normal      | μ = 0.1, σ = 0.0161812                   |
+            +---------------+-------------+------------------------------------------+
+            | :math:`r`     | Log-Normal  | μ_log = 7.71, σ_log = 1.0056             |
+            +---------------+-------------+------------------------------------------+
+            | :math:`T_u`   | Uniform     | a = 63,070, b = 115,600                  |
+            +---------------+-------------+------------------------------------------+
+            | :math:`H_u`   | Uniform     | a = 990, b = 1,110                       |
+            +---------------+-------------+------------------------------------------+
+            | :math:`T_\ell`| Uniform     | a = 63.1, b = 116                        |
+            +---------------+-------------+------------------------------------------+
+            | :math:`H_\ell`| Uniform     | a = 700, b = 820                         |
+            +---------------+-------------+------------------------------------------+
+            | :math:`L`     | Uniform     | a = 1,120, b = 1,680                     |
+            +---------------+-------------+------------------------------------------+
+            | :math:`K_w`   | Uniform     | a = 9,855, b = 12,045                    |
+            +---------------+-------------+------------------------------------------+
 
         The input random variables are independent.
 
@@ -51,7 +82,7 @@ class BoreholeSensitivity(SensitivityBenchmarkProblem):
         The sparse polynomial chaos expansion used an hyperbolic enumeration
         rule and a polynomial degree 6.
         The coefficients were estimated from regression.
-        With 1000  points in the validation set, the Q2 was greater than 99.9%.
+        With 1000  points in the validation set, the Q² was greater than 99.9%.
         There are 2 significant digits in the reference results.
 
         References
@@ -68,7 +99,9 @@ class BoreholeSensitivity(SensitivityBenchmarkProblem):
         input_names = ["rw", "r", "Tu", "Hu", "Tl", "Hl", "L", "Kw"]
         function = ot.SymbolicFunction(
             input_names,
-            ["(2*pi_*Tu*(Hu-Hl))/(ln(r/rw)*(1+(2*L*Tu)/(ln(r/rw)*rw^2*Kw)+Tu/Tl))"],
+            [
+                "(2 * pi_ * Tu * (Hu - Hl)) / (ln(r / rw) * (1 + (2 * L * Tu) / (ln(r / rw) * rw^2 * Kw) + Tu / Tl))"
+            ],
         )
         coll = [
             ot.Normal(0.1, 0.0161812),

--- a/otbenchmark/_BorgonovoSensitivity.py
+++ b/otbenchmark/_BorgonovoSensitivity.py
@@ -11,15 +11,17 @@ class BorgonovoSensitivity(SensitivityBenchmarkProblem):
     """Class to define a Borgonovo sensitivity benchmark problem."""
 
     def __init__(self):
-        """
+        r"""
         Create a Borgonovo sensitivity problem.
 
         The function is defined by the equation:
 
         .. math::
-            g(x) = x1 * x2 + x3
+            g(\boldsymbol{x}) = x_1 x_2 + x_3
 
-        where x1, x2, x3 ~ U(0, 1).
+        for any :math:`\boldsymbol{x} \in \mathbb{R}^3`.
+        We assume that :math:`X_1, X_2, X_3 \sim \mathcal{U}(0, 1)` where
+        :math:`\mathcal{N}` is the Gaussian distribution.
 
         The input random variables are independent.
 

--- a/otbenchmark/_CrossCutFunction.py
+++ b/otbenchmark/_CrossCutFunction.py
@@ -1,6 +1,7 @@
 """
 Create a drawable cross-cut function.
 """
+
 import openturns as ot
 import pylab as pl
 import openturns.viewer as otv

--- a/otbenchmark/_DirichletSensitivity.py
+++ b/otbenchmark/_DirichletSensitivity.py
@@ -11,7 +11,7 @@ import sys
 
 class DirichletFunction(ot.OpenTURNSPythonFunction):
     """
-    The non-monotonic function of Morris f: R^20 -> R
+    The Dirichlet test function
 
     References
     ----------
@@ -106,29 +106,29 @@ class DirichletSensitivity(SensitivityBenchmarkProblem):
         The function is defined by the equation:
 
         .. math::
-            g(x) = prod_{i=1}^p (1 + g_i(x[i]))
+            g(\boldsymbol{x}) = \prod_{i=1}^p (1 + g_i(x_i))
 
-        where:
+        for any :math:`\boldsymbol{x} \in [0,1]^d` where:
 
         .. math::
             g_i(x) = \alpha_i d_i(x)
 
-        for any x in [0, 1], where d_i is the Dirichlet kernel:
+        for any :math:`x \in [0, 1]`, where :math:`d_i` is the Dirichlet kernel:
 
         .. math::
-            d_i(x) = \frac{1}{\sqrt{2i}} \frac{\sin{2i + 1} \pi x}{\sin{\pi x} - 1}
+            d_i(x) = \frac{1}{\sqrt{2i}} \frac{\sin\left((2i + 1) \pi x\right)}{\sin(\pi x) - 1}
 
-        for i=1, 2, ..., p.
-
+        for :math:`i \in \{1, 2, ..., p\}`.
         By continuity, we set:
 
         .. math::
-            d_i(0) = \frac{1}{\sqrt{2i}} \forall i=1, 2, ..., p.
+            d_i(0) = \frac{1}{\sqrt{2i}}
 
+        for :math:`i \in \{1, 2, ..., p\}`.
         The Dirichlet kernel has the properties:
 
         .. math::
-            \int_0^1 d_i(x) dx = 0,
+            \int_0^1 d_i(x) dx = 0, \qquad
             \int_0^1 d_i(x)^2 dx = 0.
 
         The input random variables are independent.

--- a/otbenchmark/_DrawEvent.py
+++ b/otbenchmark/_DrawEvent.py
@@ -1,6 +1,7 @@
 """
 Static methods to plot reliability problems.
 """
+
 import openturns as ot
 import pylab as pl
 import openturns.viewer as otv

--- a/otbenchmark/_FloodingSensitivity.py
+++ b/otbenchmark/_FloodingSensitivity.py
@@ -18,18 +18,44 @@ class FloodingSensitivity(SensitivityBenchmarkProblem):
 
         .. math::
 
-            g(x) = (\frac{Q}{K_s B \sqrt{\frac{Z_m-Z_v}{L}}})^{\frac{3}{5}}+Z_v-Z_b-H_d
+            g(\boldsymbol{x}) = \left(\frac{Q}{K_s B \sqrt{\frac{Z_m - Z_v}{L}}}\right)^{\frac{3}{5}} + Z_v - Z_b - H_d
 
         with:
 
-        - Q : maximum annual flowrate (m3/s)
-        - Ks : Strickler coefficient
-        - Zv : downstream riverbed level (m)
-        - Zm : upstream riverbed level (m)
-        - L : Length of the river in meters
-        - B : Width of the river in meters
-        - Hd : height of the dyke (m)
-        - Zb : the height of the bank (m)
+        - :math:`Q` : maximum annual flowrate (m³/s);
+        - :math:`K_s` : Strickler coefficient;
+        - :math:`Zv` : downstream riverbed level (m);
+        - :math:`Z_m` : upstream riverbed level (m);
+        - :math:`L` : Length of the river in meters;
+        - :math:`B` : Width of the river in meters;
+        - :math:`H_d` : height of the dyke (m);
+        - :math:`Z_b` : the height of the bank (m).
+
+        The next table presents the marginal distributions of
+        each random variable in the model.
+
+        .. table::
+          :widths: auto
+
+          +---------------+---------------------+------------------------------------------+
+          | Variable      | Distribution        | Parameters                               |
+          +===============+=====================+==========================================+
+          | :math:`Q`     | Truncated Gumbel    | β = 558, γ = 1013, lower bound = 0       |
+          +---------------+---------------------+------------------------------------------+
+          | :math:`K_s`   | Truncated Normal    | μ = 30, σ = 7.5, lower bound = 0         |
+          +---------------+---------------------+------------------------------------------+
+          | :math:`Z_v`   | Uniform             | a = 49, b = 51                           |
+          +---------------+---------------------+------------------------------------------+
+          | :math:`H_d`   | Uniform             | a = 7, b = 9                             |
+          +---------------+---------------------+------------------------------------------+
+          | :math:`Z_m`   | Uniform             | a = 54, b = 56                           |
+          +---------------+---------------------+------------------------------------------+
+          | :math:`Z_b`   | Triangular          | a = 55, m = 55.5, b = 56                 |
+          +---------------+---------------------+------------------------------------------+
+          | :math:`L`     | Triangular          | a = 4990, m = 5000, b = 5010             |
+          +---------------+---------------------+------------------------------------------+
+          | :math:`B`     | Triangular          | a = 295, m = 300, b = 305                |
+          +---------------+---------------------+------------------------------------------+
 
         The input random variables are independent.
 
@@ -62,7 +88,7 @@ class FloodingSensitivity(SensitivityBenchmarkProblem):
         The sparse polynomial chaos expansion used an hyperbolic enumeration
         rule and a polynomial degree 8.
         The coefficients were estimated from regression.
-        With 1000  points in the validation set, the Q2 was greater than 99.9%.
+        With 1000  points in the validation set, the Q² was greater than 99.9%.
         There are 2 significant digits in the reference results.
 
         References

--- a/otbenchmark/_FourBranchSerialSystemReliability.py
+++ b/otbenchmark/_FourBranchSerialSystemReliability.py
@@ -9,8 +9,27 @@ import openturns as ot
 
 class FourBranchSerialSystemReliability(ReliabilityBenchmarkProblem):
     def __init__(self):
-        """
+        r"""
         Creates the four-branch serial system from Waarts.
+        The event is :math:`\{g(\boldsymbol{X}) < \text{threshold}\}` where:
+
+        .. math::
+
+            g(X_1, X_2) = \min(Y_1, Y_2, Y_3, Y_4)
+
+        with:
+
+        .. math::
+
+            Y_1 &= 3 + 0.1 (X_1 - X_2)^2 - \frac{X_1 + X_2}{\sqrt{2}} \\
+            Y_2 &= 3 + 0.1 (X_1 - X_2)^2 + \frac{X_1 + X_2}{\sqrt{2}} \\
+            Y_3 &= X_1 - X_2 + \frac{7}{\sqrt{2}} \\
+            Y_4 &= X_2 - X_1 + \frac{7}{\sqrt{2}}
+
+        We have:
+
+        * :math:`X_1 \sim \mathcal{N}(\mu_1, \sigma_1)` and
+        * :math:`X_2 \sim \mathcal{N}(\mu_2, \sigma_2)`.
 
         References
         ----------

--- a/otbenchmark/_GSobolSensitivity.py
+++ b/otbenchmark/_GSobolSensitivity.py
@@ -11,24 +11,32 @@ class GSobolSensitivity(SensitivityBenchmarkProblem):
     """Class to define the g-Sobol' sensitivity benchmark problem."""
 
     def __init__(self, a=[0.0, 9.0, 99.0]):
-        """
+        r"""
         Create the g-Sobol sensitivity problem.
 
-        The model is:
+        .. math::
 
-        g(x) = prod_{i=0,..., d-1} g_i(x_i)
+           g(\boldsymbol{x}) = \prod_{i=1}^d g_i(x_i)
 
-        where d is the dimension and
+        for any :math:`\boldsymbol{x} \in \mathbb{R}^d` where:
 
         .. math::
-            g_i(x_i) = (|4 * x_i - 2.0| + a_i)/ (1 + a_i)
 
-        x_i = Uniform(0.0, 1.0)
+           g_i(x_i) = \frac{\lvert 4 x_i - 2\rvert + a_i}{1 + a_i}
 
-        for i = 0, ..., d-1.
+        for :math:`i \in \{ 1, \dots, d\}`.
+        The input random variables have the Uniform distribution:
+
+        .. math::
+
+           X_i \sim \mathcal{U}(0,1)
+
+        for :math:`i \in \{ 1, \dots, d\}` where :math:`\mathcal{U}` is the Uniform
+        distribution.
+
         The input random variables are independent.
 
-        The default dimension is equal to 3.
+        The default dimension is equal to :math:`d=3`.
 
         Parameters
         ----------
@@ -44,41 +52,44 @@ class GSobolSensitivity(SensitivityBenchmarkProblem):
         -----
 
         The dimension of the problem can be changed.
-        The exact sensitivity indices are computed from the vector a.
+        The exact sensitivity indices are computed from the vector :math:`\boldsymbol{a}`.
 
-        The function g has no derivative at X=(1/2,..., 1/2).
-        The function g is symmetric with respect to X=(1/2,..., 1/2).
+        The function g has no derivative at :math:`\boldsymbol{x} = (1/2, \dots, 1/2)^\top`.
 
-        When a[i] increases, the variable X[i] has a first order
-        indice closer to zero.
+        The function g is symmetric with respect to :math:`\boldsymbol{x} = (1/2, \dots, 1/2)^\top`.
 
-        The detailed analysis is the following:
-        * if a[i] = 0, then the variable X[i] is ”important”,
-        since 0 ≤ gi (x) ≤ 2.
-        * if a[i] = 9, then the variable X[i] is ”non important”,
-        since 0.90 ≤ gi (x) ≤ 1.10.
-        * if a[i] = 99, then the variable X[i] is ”non significant”,
-        since 0.99 ≤ gi (x) ≤ 1.01.
+        When :math:`a_i` increases, the variable :math:`X_i` has a first-order index closer to zero.
 
-        The model was first introduced in (Saltelli, Sobol', 1995).
+        A detailed analysis follows:
+
+        * If :math:`a_i = 0`, then the variable :math:`X_i` is important,
+          since :math:`0 \le g_i(x) \le 2`.
+
+        * If :math:`a_i = 9`, then the variable :math:`X_i` is non-important,
+          since :math:`0.90 \le g_i(x) \le 1.10`.
+
+        * If :math:`a_i = 99`, then the variable :math:`X_i` is non-significant,
+          since :math:`0.99 \le g_i(x) \le 1.01`.
+
+        The model was first introduced in (Saltelli & Sobol', 1995).
 
         References
         ----------
-        Saltelli, A., & Sobol', I. Y. M. (1994).
-        Sensitivity analysis for nonlinear mathematical models: numerical experience.
-        Matematicheskoe Modelirovanie, 7(11), 16-28.
+        * Saltelli, A., & Sobol', I. Y. M. (1994).
+          Sensitivity analysis for nonlinear mathematical models: numerical experience.
+          Matematicheskoe Modelirovanie, 7(11), 16-28.
 
-        Saltelli, A., & Sobol', I. M. (1995). About the use of rank transformation
-        in sensitivity analysis of model output.
-        Reliability Engineering & System Safety, 50(3), 225-239.
+        * Saltelli, A., & Sobol', I. M. (1995). About the use of rank transformation
+          in sensitivity analysis of model output.
+          Reliability Engineering & System Safety, 50(3), 225-239.
 
-        Marrel, A., Iooss, B., Van Dorpe, F., & Volkova, E. (2008).
-        An efficient methodology for modeling complex computer codes with
-        Gaussian processes.
-        Computational Statistics & Data Analysis, 52(10), 4731-4744.
+        * Marrel, A., Iooss, B., Van Dorpe, F., & Volkova, E. (2008).
+          An efficient methodology for modeling complex computer codes with
+          Gaussian processes.
+          Computational Statistics & Data Analysis, 52(10), 4731-4744.
 
-        Saltelli, A., Chan, K., & Scott, E. M. (Eds.). (2000).
-        Sensitivity analysis (Vol. 134). New York: Wiley.
+        * Saltelli, A., Chan, K., & Scott, E. M. (Eds.). (2000).
+          Sensitivity analysis (Vol. 134). New York: Wiley.
         """
 
         dimension = len(a)

--- a/otbenchmark/_GaussianProductSensitivity.py
+++ b/otbenchmark/_GaussianProductSensitivity.py
@@ -11,27 +11,50 @@ class GaussianProductSensitivity(SensitivityBenchmarkProblem):
     """Class to define a linear sum sensitivity benchmark problem."""
 
     def __init__(self, mu=[0.0] * 2, sigma=[1.0] * 2):
-        """
+        r"""
         Create a gaussian product sensitivity problem.
 
-        The model is:
+        .. math::
 
-        g(x) = x[0] * x[1] * ... * x[d-1]
+           g(\boldsymbol{x}) = x_1 \, x_2 \, \cdots \, x_d
 
-        where d is the dimension and
+        for any :math:`\boldsymbol{x} \in \mathbb{R}^d`.
+        We assume that the input random variables have Gaussian distributions:
 
-        x[i] = Normal(mu[i], sigma[i])
+        .. math::
 
-        for i = 0, ..., d-1.
+           X_i \sim \mathcal{N}\left(\mu_i,\ \sigma_i^2\right)
 
-        The default dimension is equal to 2.
+        for :math:`i \in \{1, \dots, d\}`.
+
+        The default dimension is :math:`d = 2`.
+
+        The variance of the model output is:
+
+        .. math::
+
+            \text{Var}(Y) = \prod_{i=1}^{d} \left(\mu_i^2 + \sigma_i^2\right)
+                - \prod_{i=1}^{d} \mu_i^2
+
+        The first order Sobol' index for the :math:`i`-th variable is:
+
+        .. math::
+
+            S_i = \frac{\sigma_i^2 \prod_{j=1, j \neq i}^{d} \mu_j^2}{\text{Var}(Y)}
+
+        The total order Sobol' index for the :math:`i`-th variable is:
+
+        .. math::
+
+            S_{T_i} = 1 - \frac{\mu_i^2
+                \prod_{j=1, j \neq i}^{d} \left(\mu_j^2 + \sigma_j^2\right)
+                    - \prod_{j=1}^{d} \mu_j^2}{\text{Var}(Y)}
 
         This case is interesting because interactions matters.
 
         References
         ----------
-        * "Sensitivity analysis examples with NISP"
-          Michael Baudin (INRIA), Jean-Marc Martinez (CEA)
+        * "Sensitivity analysis examples with NISP", Michael Baudin (INRIA), Jean-Marc Martinez (CEA)
 
         Parameters
         ----------

--- a/otbenchmark/_GaussianSumSensitivity.py
+++ b/otbenchmark/_GaussianSumSensitivity.py
@@ -11,32 +11,44 @@ class GaussianSumSensitivity(SensitivityBenchmarkProblem):
     """Class to define a gaussian sum sensitivity benchmark problem."""
 
     def __init__(self, a=[1.0] * 3, mu=[0.0] * 2, sigma=[1.0] * 2):
-        """
+        r"""
         Create a gaussian sum sensitivity problem.
 
         The model is:
 
-        g(x) = a[0] + a[1] * x[0] + a[2] * x[1] + ... + a[d] * x[d-1]
+        .. math::
 
-        where d is the dimension and
+           g(\boldsymbol{x}) = a_0 + a_1 x_1 + a_2 x_2
+               + \dots + a_d x_d
 
-        x[i] = Normal(mu[i], sigma[i])
+        for any :math:`\boldsymbol{x} \in \mathbb{R}^d` where
+        :math:`a_0, a_1, a_2, \ldots, a_d \in \mathbb{R}` are
+        constant parameters.
+        We assume that the input random variables have Gaussian distributions:
 
-        for i = 0, ..., d-1.
+        .. math::
 
-        The default dimension is equal to 2.
+           X_i \sim \mathcal{N}\left(\mu_i,\ \sigma_i^2\right)
 
-        The variance of the output is
+        for :math:`i \in \{1, \dots, d\}`.
 
-        V(Y) = a[1]^2 * sigma[0]^2 + ... + a[d]^2 * sigma[d-1]^2
+        The output variance is:
 
-        The first order indices are
+        .. math::
 
-        S[i] = (a[i + 1]^2 * sigma[i]^2) / V(Y)
+           \operatorname{Var}(Y) = a_1^2 \, \sigma_1^2
+               + a_2^2 \, \sigma_2^2
+               + \dots + a_d^2 \, \sigma_d^2
 
-        for i=0,1,...,dimension.
+        The first-order Sobol' indices are:
 
-        The total sensitivity indices are equal to the
+        .. math::
+
+           S_i = \frac{a_{i}^{2}\, \sigma_{i}^{2}}{\operatorname{Var}(Y)}
+
+        for :math:`i = 1, \dots, d`.
+
+        The total Sobol' sensitivity indices are equal to the
         first order indices.
 
         Parameters

--- a/otbenchmark/_IshigamiSensitivity.py
+++ b/otbenchmark/_IshigamiSensitivity.py
@@ -50,15 +50,16 @@ class IshigamiSensitivity(SensitivityBenchmarkProblem):
         return exact
 
     def __init__(self, a=7.0, b=0.1):
-        """
+        r"""
         Create a Ishigami sensitivity problem.
 
         The function is defined by the equation:
 
         .. math::
-            g(x) = sin(X1) + a * sin(X2)^2 + b * X3^4 * sin(X1)
+            g(\boldsymbol{x}) = \sin(x_1) + a \, \sin^2(x_2) + b \, x_3^4 \, \sin(x_1)
 
-        where X1, X2, X3 in Uniform([-pi, pi]).
+        for any :math:`\boldsymbol{x} \in [-\pi, \pi]^3`, where :math:`a, b` are parameters.
+        We assume that :math:`X_1, X_2, X_3 \sim \mathcal{U}([- \pi, \pi])`.
         The input random variables are independent.
 
         Parameters
@@ -83,27 +84,61 @@ class IshigamiSensitivity(SensitivityBenchmarkProblem):
 
         The distribution of the output of the Ishigami function has two modes.
 
-        The first order indice of X3 is equal to zero and the total order
-        indice of X3 is strictly posititive: the variable X3 has an influence on the
-        output only through its interaction with X1.
+        The expectation and the variance of :math:`Y` are
+
+        .. math::
+            \Expect{Y}  = \frac{a}{2}
+
+
+        and:
+
+        .. math::
+            \Var{Y} = \frac{1}{2} +  \frac{a^2}{8} +  \frac{b^2 \pi^8}{18} +  \frac{b\pi^4}{5}.
+
+
+        The Sobol' decomposition variances are
+
+        .. math::
+            V_1     = \frac{1}{2} \left(1 + b\frac{\pi^4}{5} \right)^2, \qquad
+            V_2     = \frac{a^2}{8}, \qquad
+            V_{1,3} = b^2 \pi^8 \frac{8}{225}
+
+
+        and :math:`V_3=V_{1,2} = V_{2,3}=V_{1,2,3} = 0`.
+
+        This leads to the following first order Sobol' indices:
+
+        .. math::
+            S_1 = \frac{V_1}{\Var{Y}}, \qquad S_2 = \frac{V_2}{\Var{Y}}, \qquad
+            S_3 = 0,
+
+        and the following total order indices:
+
+        .. math::
+            ST_1 = \frac{V_1+V_{1,3}}{\Var{Y}}, \qquad ST_2 = S_2, \qquad
+            ST_3 = \frac{V_{1,3}}{\Var{Y}}.
+
+        The first order indice of :math:`X_3` is equal to zero and the total order
+        indice of :math:`X_3` is strictly positive: the variable :math:`X_3` has an influence on the
+        output only through its interaction with :math:`X_1`.
 
         The detailed analysis is the following:
 
-        * The variable X1 has a total indice close to 0.6 has the
-          highest impact on the output variability, by X1 on its own or
+        * The variable :math:`X_1` has a total indice close to 0.6 has the
+          highest impact on the output variability, by :math:`X_1` on its own or
           by its interactions with other variables.
           Indeed, its first order indice is close to 0.3, which
-          implies that interactions of X1 with other variables are involved
+          implies that interactions of :math:`X_1` with other variables are involved
           in 0.6 - 0.3 = 0.3 of the variability of the output.
-        * The variable X2 has a first order indice approximately equal to 0.4,
+        * The variable :math:`X_2` has a first order indice approximately equal to 0.4,
           which is close to the total order indice.
           This shows that this variable does not interact with other variables.
-        * The variable X3 has a first order indice equal to zero.
+        * The variable :math:`X_3` has a first order indice equal to zero.
           Since its total order indice is approximately equal to 0.3,
           this shows that its impact on the output is only through its
-          interaction with X1.
+          interaction with :math:`X_1`.
 
-        The function was first introduced in (Ishigami, Homma, 1990).
+        The function was first introduced in (Ishigami & Homma, 1990).
 
         References
         ----------

--- a/otbenchmark/_MorrisSensitivity.py
+++ b/otbenchmark/_MorrisSensitivity.py
@@ -1,6 +1,7 @@
 """
 The non-monotonic function of Morris f: R^20 -> R.
 """
+
 from ._SensitivityBenchmarkProblem import SensitivityBenchmarkProblem
 import openturns as ot
 import warnings
@@ -125,30 +126,44 @@ class MorrisSensitivity(SensitivityBenchmarkProblem):
     """Class to define the Morris sensitivity benchmark problem."""
 
     def __init__(self, random_parameters=False):
-        """
+        r"""
         Define the Morris sensitivity benchmark problem.
 
-        The function g is from [0,1]^20 to R.
+        The function :math:`g` is defined on :math:`[0,1]^{20}` and takes
+        values in :math:`\mathbb{R}`.
 
-        Its input distribution are Uniform([0, 1]) random variables.
-        The input random variables are independent.
+        Its inputs are independent random variables with distribution
+        :math:`\mathcal{U}(0,1)`.
 
-        It is defined as the sum:
+        It is defined as:
 
-        g(x) = beta_0
-        + sum_i beta[i] * w[i](x)
-        + sum_{ij} beta[i, j] * w[i](x) * w[j](x)
-        + sum_{ijk} beta[i, j, k] * w[i](x) * w[j](x) * w[k](x)
-        + sum_{ijkl} beta[i, j, k, l] * w[i](x) * w[j](x) * w[k](x) * w[l](x)
+        .. math::
 
-        where
+           g(\boldsymbol{x}) & = \beta_0
+                  + \sum_{i} \beta_i\, w_i(x) \\
+                & \quad + \sum_{i<j} \beta_{i,j}\, w_i(x)\, w_j(x) \\
+                & \quad + \sum_{i<j<k} \beta_{i,j,k}\, w_i(x)\, w_j(x)\, w_k(x) \\
+                & \quad + \sum_{i<j<k<\ell} \beta_{i,j,k,\ell}\, w_i(x)\, w_j(x)\, w_k(x)\, w_\ell(x)
 
-        w[i](x) = 2 * (x[i] - 0.5) for 𝑖=1,2,4,6,8,...,20
+        for any :math:`\boldsymbol{x} \in [0,1]^{20}` where:
 
-        and
+        .. math::
 
-        w[i](x) = 2 * (1.1 * x[i] / (x[i] + 1) - 0.5) for 𝑖=3,5,7.
+           w_i(x) = 2\,(x_i - 0.5)
 
+        for :math:`i \in \{1, 2, 4, 6, 8, \dots, 20\}`, and:
+
+        .. math::
+
+           w_i(x) = 2\,\left(\frac{1.1\, x_i}{x_i + 1} - 0.5\right)
+
+        for :math:`i \in \{3, 5, 7\}`.
+        The parameters :math:`(\beta_i)_{1 \leq i \leq 20}`,
+        :math:`(\beta_{i,j})_{1 \leq i, j \leq 20}`,
+        :math:`(\beta_{i,j, k})_{1 \leq i, j, k\leq 20}`,
+        :math:`(\beta_{i,j, k, \ell})_{1 \leq i, j, k, \ell \leq 20}`
+        are presented below, in the **Notes** section.
+        In (Morris, 1991)'s paper, these parameters are random.
         In order to get consistent results, the default value of the
         random_parameters parameter is so that the parameters beta
         are constant, deterministic, values.
@@ -168,13 +183,16 @@ class MorrisSensitivity(SensitivityBenchmarkProblem):
         The dimension of this problem is equal to 20 and cannot be changed.
 
         The function is the sum of five functions.
-        * The first is constant and equal to beta_0.
-        * The second is a linear combination of w[i] coefficients.
-        * The third is a order 2 combination of w[i] coefficients.
-        * The fourth is a order 3 combination of w[i] coefficients.
-        * The fifth is a order 4 combination of w[i] coefficients.
 
-        Therefore, Morris's function is an order 4 polynomial.
+        * The first function is constant and equal to :math:`\beta_0`.
+        * The second is a linear combination of :math:`\boldsymbol{w}` coefficients.
+        * The third is a order 2 combination of :math:`\boldsymbol{w}` coefficients.
+        * The fourth is a order 3 combination of :math:`\boldsymbol{w}` coefficients.
+        * The fifth is a order 4 combination of :math:`\boldsymbol{w}` coefficients.
+
+        Therefore, Morris's function is a modification of an order 4 polynomial,
+        where the small non-linearity comes from the :math:`\boldsymbol{w}`
+        coefficients.
 
         This code was taken from otmorris/python/src/Morris.i.
 
@@ -185,13 +203,58 @@ class MorrisSensitivity(SensitivityBenchmarkProblem):
         The sparse polynomial chaos expansion used an hyperbolic enumeration
         rule and a polynomial degree 4.
         The coefficients were estimated from regression.
-        With 500 points in the validation set, the Q2 was greater than 98%.
+        With 500 points in the validation set, the Q² was greater than 98%.
         There are 2 significant digits in the reference results.
+
+        **Morris Function Parameters**
+
+        Let :math:`\mathcal{N}(0,1)` be a random Gaussian variable with zero
+        mean and unit standard deviation.
+
+        The first order coefficients of the Morris function are:
+
+        .. math::
+
+            \beta_i =
+            \begin{cases}
+            20 & \text{if } i = 1,\ldots,10, \\
+            \mathcal{N}(0,1) & \text{otherwise}.
+            \end{cases}
+
+        The second order coefficients are:
+
+        .. math::
+
+            \beta_{i,j} =
+            \begin{cases}
+            -15 & \text{if } i,j \in \{1,\ldots,6\}, \\
+            \mathcal{N}(0,1) & \text{otherwise}.
+            \end{cases}
+
+        The third order coefficients are:
+
+        .. math::
+
+            \beta_{i,j,\ell} =
+            \begin{cases}
+            -10 & \text{if } i,j,\ell \in \{1,\ldots,5\},\\
+            0 & \text{otherwise}.
+            \end{cases}
+
+        The fourth order coefficients are:
+
+        .. math::
+
+            \beta_{i,j,\ell,s} =
+            \begin{cases}
+            5 & \text{if } i,j,\ell,s \in \{1,\ldots,4\},\\
+            0 & \text{otherwise}.
+            \end{cases}
 
         References
         ----------
-        M. D. Morris, 1991, Factorial sampling plans for preliminary
-        computational experiments,Technometrics, 33, 161--174.
+        * M. D. Morris, 1991, Factorial sampling plans for preliminary
+          computational experiments, Technometrics, 33, 161--174.
         """
         # Define the function
         dimension = 20

--- a/otbenchmark/_NLOscillatorSensitivity.py
+++ b/otbenchmark/_NLOscillatorSensitivity.py
@@ -18,41 +18,51 @@ class NLOscillatorSensitivity(SensitivityBenchmarkProblem):
         The function is defined by the equation:
 
         .. math::
-            g(x) = fs - 3*ks*\sqrt{\pi*S0/(4.*xis*omegas^3)*
-                xi_a*xis/(xip*xis*(4.*xi_a^2+theta^2)+gamma*xi_a^2)*
-                (xip*omegap^3+xis*omegas^3)*omegap/(4.*xi_a*omegaa^4)}
+            g(\boldsymbol{x}) = f_s - 3 k_s \sqrt{
+                \frac{\pi S_0}{4\, \xi_s\, \omega_s^{3}}
+                \cdot
+                \frac{\xi_a\, \xi_s}{
+                    \xi_p\, \xi_s (4 \xi_a^{2} + \theta^{2})
+                    + \gamma\, \xi_a^{2}
+                }
+                \cdot
+                \frac{( \xi_p\, \omega_p^{3} + \xi_s\, \omega_s^{3} ) \omega_p}{4\, \xi_a\, \omega_a^{4}}
+                }
 
-        where
-        * omegap = np.sqrt(kp/mp)
-        * omegas = np.sqrt(ks/ms)
-        * omegaa = 0.5*(omegap+omegas)
-        * gamma = ms/mp
-        * xi_a = 0.5*(xip+xis)
-        * theta = 1./omegaa*(omegap-omegas)
+        where:
+
+        * :math:`\omega_p = \sqrt{k_p / m_p}`
+        * :math:`\omega_s = \sqrt{k_s / m_s}`
+        * :math:`\omega_a = \frac{1}{2} (\omega_p + \omega_s)`
+        * :math:`\gamma = m_s / m_p`
+        * :math:`\xi_a = \frac{1}{2} (\xi_p + \xi_s)`
+        * :math:`\theta = \frac{1}{\omega_a (\omega_p - \omega_s)}`
 
         The input random variables are independent.
 
         The aim is to assess reliability of a two-degree-of-freedom
         primary-secondary system under a white noise base acceleration.
 
-        The basic variables characterizing the physical behavior are
-        * the masses mp and ms
-        * spring stiffnesses kp and ks
-        * natural frequencies ωp and ωs
-        * damping ratios ξp and ξs
+        The basic variables characterizing the physical behavior are:
 
-        where the subscripts p and s respectively refer to
+        * the masses :math:`m_p` and :math:`m_s`;
+        * spring stiffnesses :math:`k_p` and :math:`k_s`;
+        * natural frequencies :math:`\omega_p` and :math:`\omega_s`;
+        * damping ratios :math:`\xi_p` and :math:`\xi_s`;
+
+        where the subscripts :math:`p` and :math:`s` respectively refer to
         the primary and secondary oscillators.
 
         The variables in the model are:
-        * Fs : the force capacity of the secondary spring,
-        * S0 is the intensity of the white noise,
-        * ωp=(kp/mp)1/2,
-        * ωs=(ks/ms)1/2,
-        * ωa=(ωp+ωs)/2 the average frequency ratio,
-        * γ=ms/mp the mass ratio,
-        * ξa=(ξp+ξs)/2 the average damping ratio and
-        * r=(ωp−ωs)/ωa a tuning parameter.
+
+        * :math:`F_s` : the force capacity of the secondary spring,
+        * :math:`S_0` is the intensity of the white noise,
+        * :math:`\omega_p = \frac{1}{2} (k_p / m_p)`,
+        * :math:`\omega_s = \frac{1}{2} (k_s / m_s)`,
+        * :math:`\omega_a = \frac{1}{2} (\omega_p + \omega_s)` the average frequency ratio,
+        * :math:`\gamma = m_s / m_p` the mass ratio,
+        * :math:`\xi_a = (\xi_p + \xi_s)/2` the average damping ratio and
+        * :math:`r = (\omega_p - \omega_s) / \omega_a` a tuning parameter.
 
         Parameters
         ----------

--- a/otbenchmark/_OakleyOHaganSensitivity.py
+++ b/otbenchmark/_OakleyOHaganSensitivity.py
@@ -18,9 +18,16 @@ class OakleyOHaganSensitivity(SensitivityBenchmarkProblem):
         The function is defined by the equation:
 
         .. math::
-            g(x) = x'Mx+a1'x + a2' \sin(x) + a3'\cos(x)
+            g(\boldsymbol{x}) = \boldsymbol{x}^\top M \boldsymbol{x}
+                + \boldsymbol{a}_1^\top \boldsymbol{x}
+                + \boldsymbol{a}_2^\top \sin(\boldsymbol{x}) + \boldsymbol{a}_3^\top \cos(\boldsymbol{x})
 
-        where :math:`x_1, \hdots, x_{15} \sim N(0, 1)`
+        where :math:`\boldsymbol{x} \in \mathbb{R}^{15}`, :math:`M \in \mathbb{R}^{15 \times 15}`
+        is a deterministic matrix and :math:`\boldsymbol{a}_1, \boldsymbol{a}_2, \boldsymbol{a}_3 \in \mathbb{R}^{15}`
+        are three deterministic vectors.
+
+        We assume that :math:`X_1, \ldots, X_{15} \sim \mathcal{N}(0, 1)` where
+        :math:`\mathcal{N}` is the Gaussian distribution.
 
         The input random variables are independent.
 
@@ -35,7 +42,7 @@ class OakleyOHaganSensitivity(SensitivityBenchmarkProblem):
         The Sobol' sensitivity indices are estimate with as
         much accuracy as possible.
 
-        The model was first introduced in (Oakley, O'Hagan, 2004).
+        The model was first introduced in (Oakley & O'Hagan, 2004).
 
         The reference Sobol' indices were computed from a sparse
         polynomial chaos.

--- a/otbenchmark/_ReliabilityBenchmarkMetaAlgorithm.py
+++ b/otbenchmark/_ReliabilityBenchmarkMetaAlgorithm.py
@@ -1,6 +1,7 @@
 """
 Manage reliability problems.
 """
+
 import otbenchmark as otb
 
 

--- a/otbenchmark/_ReliabilityBenchmarkResult.py
+++ b/otbenchmark/_ReliabilityBenchmarkResult.py
@@ -1,6 +1,7 @@
 """
 Manage reliability problems.
 """
+
 import otbenchmark as otb
 
 

--- a/otbenchmark/_ReliabilityProblem107.py
+++ b/otbenchmark/_ReliabilityProblem107.py
@@ -12,16 +12,23 @@ import openturns as ot
 
 class ReliabilityProblem107(ReliabilityBenchmarkProblem):
     def __init__(self, threshold=0.0, mu=0, sigma=1):
-        """
+        r"""
         Creates a reliability problem RP107.
 
-        The event is {g(X) < threshold} where
+        The event is :math:`\{g(\boldsymbol{X}) < \text{threshold}\}` where
 
-        X = (x1, x2, ...., x10)
+        .. math::
 
-        g(X) = 5*sqrt(10) -(x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10).
+          g(X) = 5 \sqrt{10} - (x_1 + x_2 + x_3 + x_4 + x_5 + x_6 + x_7 + x_8 + x_9 + x_{10}).
 
-        We have xi ~ Normal(0, 1) for i in {1, 2, ...,10}
+        for any :math:`\boldsymbol{x} \in \mathbb{R}^{10}`.
+
+        We have:
+
+        .. math::
+            X_i \sim \mathcal{N}(0, 1)
+
+        for :math:`i \in \{1, 2, ...,10\}`.
 
         Parameters
         ----------

--- a/otbenchmark/_ReliabilityProblem110.py
+++ b/otbenchmark/_ReliabilityProblem110.py
@@ -12,18 +12,36 @@ import openturns as ot
 
 class ReliabilityProblem110(ReliabilityBenchmarkProblem):
     def __init__(self, threshold=0.0, mu=[0.0] * 2, sigma=[1.0] * 2):
-        """
+        r"""
         Creates a reliability problem RP110.
 
-        The event is {g(X) < threshold} where
+        The event is :math:`\{g(\boldsymbol{X}) < \text{threshold}\}` where:
 
-        g(x1, x2) = min(g1, g2) with :
+        .. math::
+            g(\boldsymbol{x}) = \min(g_1(\boldsymbol{x}), g_2(\boldsymbol{x}))
 
-        g1 = 0.85 - 0.1 * x1 if x1 <= 3.5 else g1 = 4 - x1
+        for any :math:`\boldsymbol{x} \in \mathbb{R}^2` with :
 
-        g2 = 2.3 - x2 if x2 <= 2 else g2 = 0.5 - 0.1 * x2
+        .. math::
+            g_1(\boldsymbol{x}) =
+            \begin{cases}
+            0.85 - 0.1 x_1 & \text{ if } x_1 \leq 3.5, \\
+            4 - x_1 & \text{otherwise,}
+            \end{cases}
 
-        We have x1 ~ Normal(mu[0], sigma[0]) and x2 ~ Normal(mu[1], sigma[1]).
+        and:
+
+        .. math::
+            g_2(\boldsymbol{x}) =
+            \begin{cases}
+            2.3 - x_2  & \text{ if }  x_2 \leq 2, \\
+            0.5 - 0.1 x_2 & \text{otherwise,}
+            \end{cases}
+
+        We have:
+
+        * :math:`X_1 \sim \mathcal{N}(\mu_1, \sigma_1^2)` and
+        * :math:`X_2 \sim \mathcal{N}(\mu_2, \sigma_2^2)`.
 
         Parameters
         ----------
@@ -36,14 +54,8 @@ class ReliabilityProblem110(ReliabilityBenchmarkProblem):
             the gaussian distributions.
         """
         equations = [
-            "if (x0 <= 3.5)",
-            "var g1 := 0.85 - 0.1 * x0;",
-            "else",
-            "  g1 := 4 - x0;",
-            "if (x1 <= 2.0)",
-            "  var g2 := 2.3 - x1;",
-            "else",
-            "  g2 := 0.5 - 0.1 * x1;",
+            "var g1 := (x0 <= 3.5) ? 0.85 - 0.1 * x0 : 4 - x0;",
+            "var g2 := (x1 <= 2.0) ? 2.3 - x1 : 0.5 - 0.1 * x1;",
             "gsys := min(g1, g2);",
         ]
         program = "\n".join(equations)

--- a/otbenchmark/_ReliabilityProblem111.py
+++ b/otbenchmark/_ReliabilityProblem111.py
@@ -12,14 +12,20 @@ import openturns as ot
 
 class ReliabilityProblem111(ReliabilityBenchmarkProblem):
     def __init__(self, threshold=0.0, mu=[0.0] * 2, sigma=[1.0] * 2):
-        """
+        r"""
         Creates a reliability problem RP111.
 
-        The event is {g(X) < threshold} where
+        The event is :math:`\{g(\boldsymbol{X}) < \text{threshold}\}` where
 
-        g(x1, x2) = 12.5 - abs(x1 * x2)
+        .. math::
+          g(x_1, x_2) = 12.5 - |x_1 x_2|
 
-        We have x1 ~ Normal(mu[0], sigma[0]) and x2 ~ Normal(mu[1], sigma[1]).
+        for any :math:`\boldsymbol{x} \in \mathbb{R}^2`.
+
+        We have:
+
+        * x1 ~ Normal(mu[0], sigma[0]) and
+        * x2 ~ Normal(mu[1], sigma[1]).
 
         Parameters
         ----------

--- a/otbenchmark/_ReliabilityProblem14.py
+++ b/otbenchmark/_ReliabilityProblem14.py
@@ -26,25 +26,25 @@ class ReliabilityProblem14(ReliabilityBenchmarkProblem):
         mu5=250000.0,
         sigma5=35000.0,
     ):
-        """
+        r"""
         Creates a reliability problem RP14.
 
-        The event is {g(X) < threshold} where
+        The event is :math:`\{g(\boldsymbol{X}) < \text{threshold}\}` where:
 
-        X = (x1, x2, x3, x4, x5)
+        .. math::
 
-        g(X) = x1 - 32 / (pi * x2^3) * sqrt(x3^2 * x4^2 / 16 + x5^2)
+          g(\boldsymbol{x}) = x_1 - \frac{32}{\pi x_2^3} \sqrt{\frac{x_3^2 x_4^2}{16} + x_5^2}
+
+        for any :math:`\boldsymbol{x} \in \mathbb{R}^5`.
+
 
         We have :
-            x1 ~ Uniform(a, b)
 
-            x2 ~ Normal(mu2, sigma2)
-
-            x3 ~ Gumbel-max(mu3, sigma3)
-
-            x4 ~ Normal(mu4, sigma4)
-
-            x5 ~ Normal(mu5, sigma5)
+        *    x1 ~ Uniform(a, b)
+        *    x2 ~ Normal(mu2, sigma2)
+        *    x3 ~ Gumbel-max(mu3, sigma3)
+        *    x4 ~ Normal(mu4, sigma4)
+        *    x5 ~ Normal(mu5, sigma5)
 
         Parameters
         ----------

--- a/otbenchmark/_ReliabilityProblem22.py
+++ b/otbenchmark/_ReliabilityProblem22.py
@@ -12,14 +12,21 @@ import openturns as ot
 
 class ReliabilityProblem22(ReliabilityBenchmarkProblem):
     def __init__(self, threshold=0.0, mu=[0.0] * 2, sigma=[1.0] * 2):
-        """
+        r"""
         Creates a reliability problem RP22.
 
-        The event is {g(X) < threshold} where
+        The event is :math:`\{g(\boldsymbol{X}) < \text{threshold}\}` where:
 
-        g(x1, x2) = 2.5 - 1 / sqrt(2) * (x1 + x2) + 0.1 * (x1 - x2) ^2
+        .. math::
 
-        We have x1 ~ Normal(mu[0], sigma[0]) and x2 ~ Normal(mu[1], sigma[1]).
+            g(x_1, x_2) = 2.5 - \frac{1}{\sqrt{2}} (x_1 + x_2) + 0.1 (x_1 - x_2)^2
+
+        for any :math:`\boldsymbol{x} \in \mathbb{R}^2`.
+
+        We have:
+
+        * x1 ~ Normal(mu[0], sigma[0]) and
+        * x2 ~ Normal(mu[1], sigma[1]).
 
         Parameters
         ----------

--- a/otbenchmark/_ReliabilityProblem24.py
+++ b/otbenchmark/_ReliabilityProblem24.py
@@ -12,14 +12,21 @@ import openturns as ot
 
 class ReliabilityProblem24(ReliabilityBenchmarkProblem):
     def __init__(self, threshold=0.0, mu=[10.0] * 2, sigma=[3.0] * 2):
-        """
+        r"""
         Creates a reliability problem RP24.
 
-        The event is {g(X) < threshold} where
+        The event is :math:`\{g(\boldsymbol{X}) < \text{threshold}\}` where:
 
-        g(x1, x2) = 2.5 - 0.2357 * (x1 - x2) + 0.00463 * (x1 + x2 - 20)^4
+        .. math::
 
-        We have x1 ~ Normal(mu[0], sigma[0]) and x2 ~ Normal(mu[1], sigma[1]).
+            g(x_1, x_2) = 2.5 - 0.2357 (x_1 - x_2) + 0.00463 (x_1 + x_2 - 20)^4
+
+        for any :math:`\boldsymbol{x} \in \mathbb{R}^2`.
+
+        We have:
+
+        * x1 ~ Normal(mu[0], sigma[0]) and
+        * x2 ~ Normal(mu[1], sigma[1]).
 
         Parameters
         ----------

--- a/otbenchmark/_ReliabilityProblem25.py
+++ b/otbenchmark/_ReliabilityProblem25.py
@@ -12,14 +12,21 @@ import openturns as ot
 
 class ReliabilityProblem25(ReliabilityBenchmarkProblem):
     def __init__(self, threshold=0.0, mu=[0.0] * 2, sigma=[1.0] * 2):
-        """
+        r"""
         Creates a reliability problem RP25.
 
-        The event is {g(X) < threshold} where
+        The event is :math:`\{g(\boldsymbol{X}) < \text{threshold}\}` where
 
-        g(x1, x2) = max(x1^2 - 8 * x2 + 16, -16 * x1 + x2 + 32)
+        .. math::
 
-        We have x1 ~ Normal(mu[0], sigma[0]) and x2 ~ Normal(mu[1], sigma[1]).
+            g(x_1, x_2) = \max(x_1^2 - 8 x_2 + 16, -16 x_1 + x_2 + 32)
+
+        for any :math:`\boldsymbol{x} \in \mathbb{R}^2`.
+
+        We have:
+
+        * x1 ~ Normal(mu[0], sigma[0]) and
+        * x2 ~ Normal(mu[1], sigma[1]).
 
         Parameters
         ----------

--- a/otbenchmark/_ReliabilityProblem28.py
+++ b/otbenchmark/_ReliabilityProblem28.py
@@ -14,16 +14,22 @@ class ReliabilityProblem28(ReliabilityBenchmarkProblem):
     def __init__(
         self, threshold=146.14, mu1=78064.0, sigma1=11710.0, mu2=0.0104, sigma2=0.00156
     ):
-        """
+        r"""
         Creates a reliability problem RP28.
 
-        The event is {g(X) < threshold} where
+        The event is :math:`\{g(\boldsymbol{X}) < \text{threshold}\}` where:
 
-        g(x1, x2) = x1 * x2 - threshold
+        .. math::
 
-        with threshold = 146.14.
+          g(x_1, x_2) = x_1 x_2 - \text{threshold}
 
-        We have x1 ~ Normal(mu1, sigma1) and x2 ~ Normal(mu2, sigma2).
+        for any :math:`\boldsymbol{x} \in \mathbb{R}^2`
+        where :math:`\text{threshold} = 146.14`.
+
+        We have:
+
+        * x1 ~ Normal(mu1, sigma1) and
+        * x2 ~ Normal(mu2, sigma2).
 
         Parameters
         ----------

--- a/otbenchmark/_ReliabilityProblem31.py
+++ b/otbenchmark/_ReliabilityProblem31.py
@@ -12,14 +12,20 @@ import openturns as ot
 
 class ReliabilityProblem31(ReliabilityBenchmarkProblem):
     def __init__(self, threshold=0.0, mu=[0.0] * 2, sigma=[1.0] * 2):
-        """
+        r"""
         Creates a reliability problem RP31.
 
-        The event is {g(X) < threshold} where
+        The event is :math:`\{g(\boldsymbol{X}) < \text{threshold}\}` where
 
-        g(x1, x2) = 2 - x2 + 256 * x1^4
+        .. math::
 
-        We have x1 ~ Normal(mu[0], sigma[0]) and x2 ~ Normal(mu[1], sigma[1]).
+            g(x_1, x_2) = 2 - x_2 + 256 x_1^4
+
+        for any :math:`\boldsymbol{x} \in \mathbb{R}^2`.
+        We have:
+
+        * x1 ~ Normal(mu[0], sigma[0]) and
+        * x2 ~ Normal(mu[1], sigma[1]).
 
         Parameters
         ----------

--- a/otbenchmark/_ReliabilityProblem33.py
+++ b/otbenchmark/_ReliabilityProblem33.py
@@ -17,24 +17,32 @@ class ReliabilityProblem33(ReliabilityBenchmarkProblem):
         mu=[0.0] * 3,
         sigma=[1.0] * 3,
     ):
-        """
+        r"""
         Creates a reliability problem RP33.
 
-        The limit-state g is defined by:
+        The limit-state g function is defined by:
 
-            g(x1, x2, x3) = min(g1, g2) with
+        .. math::
 
-            g1 = -x1 - x2 - x3 + 3 * sqrt(3)
+            g(x_1, x_2, x_3) = \min(g_1, g_2)
 
-            g2 = -x3 + 3
+        with:
+
+        .. math::
+
+            g_1(x_1, x_2, x_3) = -x_1 - x_2 - x_3 + 3 \sqrt{3}
+
+        and:
+
+        .. math::
+
+            g_2(x_1, x_2, x_3) = -x_3 + 3
 
         We have:
 
-            x1 ~ Normal(mu[0], sigma[0])
-
-            x2 ~ Normal(mu[1], sigma[1])
-
-            x3 ~ Normal(mu[2], sigma[2]).
+        * x1 ~ Normal(mu[0], sigma[0]),
+        * x2 ~ Normal(mu[1], sigma[1]),
+        * x3 ~ Normal(mu[2], sigma[2]).
 
         Parameters
         ----------

--- a/otbenchmark/_ReliabilityProblem35.py
+++ b/otbenchmark/_ReliabilityProblem35.py
@@ -12,18 +12,31 @@ import openturns as ot
 
 class ReliabilityProblem35(ReliabilityBenchmarkProblem):
     def __init__(self, threshold=0.0, mu=[0.0] * 2, sigma=[1.0] * 2):
-        """
+        r"""
         Creates a reliability problem RP35.
 
-        The event is {g(X) < threshold} where
+        The event is :math:`\{g(\boldsymbol{X}) < \text{threshold}\}` where
 
-        g(x1, x2) = min(g1, g2) with
+        .. math::
 
-        g1 = 2 - x2 + exp(-0.1 * x1^2) + (0.2 * x1) ^ 4
+          g(x_1, x_2) = \min(g_1, g_2)
 
-        g2 = 4.5 - x1 * x2
+        where:
 
-        We have x1 ~ Normal(mu[0], sigma[0]) and x2 ~ Normal(mu[1], sigma[1]).
+        .. math::
+
+          g_1(x_1, x_2) = 2 - x2 + \exp(-0.1 x_1^2) + (0.2 x_1)^4
+
+        and:
+
+        .. math::
+
+          g_2(x_1, x_2) = 4.5 - x_1 x_2
+
+        We have:
+
+        * x1 ~ Normal(mu[0], sigma[0]) and
+        * x2 ~ Normal(mu[1], sigma[1]).
 
         Parameters
         ----------

--- a/otbenchmark/_ReliabilityProblem38.py
+++ b/otbenchmark/_ReliabilityProblem38.py
@@ -30,32 +30,30 @@ class ReliabilityProblem38(ReliabilityBenchmarkProblem):
         mu7=0.036,
         sigma7=0.0036,
     ):
-        """
+        r"""
         Creates a reliability problem RP38.
 
-        The event is {g(X) < threshold} where
-
-        X = (x1, x2, x3, x4, x5, x6, x7)
+        The event is :math:`\{g(\boldsymbol{X}) < \text{threshold}\}` where
 
         .. math::
-            g(X) = 15.59 * 1e4 - x1 *x2^3 / (2 * x3^3)
-            * ((x4^2 - 4 * x5 * x6 * x7^2 +x4 * (x6 + 4 * x5 + 2 *x6 * x7))
-            / (x4 * x5 * (x4 + x6 + 2 *x6 *x7)))
+            g(\boldsymbol{x}) = \alpha - \frac{x_1 x_2^3}{2 x_3^3}
+            \frac{x_4^2 - 4 x_5 x_6 x_7^2 + x_4 (x_6 + 4 x_5 + 2 x_6 x_7)}{x_4 x_5 (x_4 + x_6 + 2 x_6 x_7)}
+
+        for any :math:`\boldsymbol{x} \in \mathbb{R}^7` where :math:`\alpha`
+        is a parameter:
+
+        .. math::
+          \alpha = 15.59 \times 10^4
 
         We have :
-        x1 ~ Normal(mu1, sigma1)
 
-        x2 ~ Normal(mu2, sigma2)
-
-        x3 ~ Normal(mu3, sigma3)
-
-        x4 ~ Normal(mu4, sigma4)
-
-        x5 ~ Normal(mu5, sigma5)
-
-        x6 ~ Normal(mu6, sigma6)
-
-        x7 ~ Normal(mu7, sigma7)
+        * x1 ~ Normal(mu1, sigma1),
+        * x2 ~ Normal(mu2, sigma2),
+        * x3 ~ Normal(mu3, sigma3),
+        * x4 ~ Normal(mu4, sigma4),
+        * x5 ~ Normal(mu5, sigma5),
+        * x6 ~ Normal(mu6, sigma6),
+        * x7 ~ Normal(mu7, sigma7).
 
         Parameters
         ----------
@@ -90,7 +88,6 @@ class ReliabilityProblem38(ReliabilityBenchmarkProblem):
         sigma7 : float
             The standard deviation of the X7 Normal distribution.
         """
-
         formula = "15.59 * 1e4 - x1 *x2^3 / (2 * x3^3) *"
         formula += "((x4^2 - 4 * x5 * x6 * x7^2 + "
         formula += (

--- a/otbenchmark/_ReliabilityProblem53.py
+++ b/otbenchmark/_ReliabilityProblem53.py
@@ -16,14 +16,19 @@ import openturns as ot
 
 class ReliabilityProblem53(ReliabilityBenchmarkProblem):
     def __init__(self, threshold=0.0, mu1=1.5, sigma1=1.0, mu2=2.5, sigma2=1.0):
-        """
+        r"""
         Creates a reliability problem RP53.
 
-        The event is {g(X) < threshold} where
+        The event is :math:`\{g(\boldsymbol{X}) < \text{threshold}\}` where:
 
-        g(X1, X2) = sin(5 * X1 / 2) + 2 - (X1^2 + 4) * (X2 - 1) / 20
+        .. math::
 
-        We have X1 ~ Normal(mu1, sigma1) and X2 ~ Normal(mu2, sigma2).
+            g(X_1, X_2) = \sin(5 X_1 / 2) + 2 - (X_1^2 + 4) (X_2 - 1) / 20
+
+        We have:
+
+        * X1 ~ Normal(mu1, sigma1) and
+        * X2 ~ Normal(mu2, sigma2).
 
         Parameters
         ----------

--- a/otbenchmark/_ReliabilityProblem54.py
+++ b/otbenchmark/_ReliabilityProblem54.py
@@ -12,14 +12,17 @@ import openturns as ot
 
 class ReliabilityProblem54(ReliabilityBenchmarkProblem):
     def __init__(self, threshold=0.0, expo=1):
-        """
+        r"""
         Creates a reliability problem RP54.
 
-        The event is {g(X) < threshold} where
+        The event is :math:`\{g(\boldsymbol{X}) < \text{threshold}\}` where:
 
-        X = (x1, x2, ..., x20)
+        .. math::
+          g(\boldsymbol{x}) = x_1 + x_2 + ... + x_{20} - 8.951
 
-        g(X) = (x1 + x2 + ... + x20) - 8.951
+        for any :math:`\boldsymbol{x} \in \mathbb{R}^{20}`.
+
+        Each random variable has the Exponential distribution.
 
         Parameters
         ----------

--- a/otbenchmark/_ReliabilityProblem55.py
+++ b/otbenchmark/_ReliabilityProblem55.py
@@ -10,24 +10,36 @@ import openturns as ot
 
 class ReliabilityProblem55(ReliabilityBenchmarkProblem):
     def __init__(self, threshold=0.0, a=[-1.0] * 2, b=[1.0] * 2):
-        """
+        r"""
         Creates a reliability problem RP55.
 
-        The event is {g(X) < threshold} where
+        The event is :math:`\{g(\boldsymbol{X}) < \text{threshold}\}` where
 
-        X = (x1, x2)
+        .. math::
 
-        g1 = 0.2 + 0.6 * (x1 - x2)^4 - (x1 - x2) / sqrt(2)
+        g(\boldsymbol{x}) = \min(g_1(\boldsymbol{x}), g_2(\boldsymbol{x}),
+          g_3(\boldsymbol{x}), g_4(\boldsymbol{x}))
 
-        g2 = 0.2 + 0.6 * (x1 - x2)^4 + (x1 - x2) / sqrt(2)
+        for any :math:`\boldsymbol{x} \in \mathbb{R}^2`
+        where:
 
-        g3 = (x1 - x2) + 5 / sqrt(2) - 2.2
+        .. math::
 
-        g4 = (x2 - x1) + 5 / sqrt(2) - 2.2
+          g_1(\boldsymbol{x}) & = 0.2 + 0.6 (x_1 - x_2)^4
+            - \frac{x_1 - x_2}{\sqrt{2}}
 
-        g(X) = min(g1, g2, g3, g4)
 
-        We have x1 ~ Uniform(a[0], b[0]) and x2 ~ Uniform(a[1], b[1]).
+          g_2(\boldsymbol{x}) & = 0.2 + 0.6 (x_1 - x_2)^4
+            + \frac{x_1 - x_2}{\sqrt{2}}
+
+          g_3(\boldsymbol{x}) & = (x_1 - x_2) + \frac{5}{\sqrt{2}} - 2.2
+
+          g_4(\boldsymbol{x}) & = (x_2 - x_1) + \frac{5}{\sqrt{2}} - 2.2
+
+        We have:
+
+        * x1 ~ Uniform(a[0], b[0]) and
+        * x2 ~ Uniform(a[1], b[1]).
 
         Parameters
         ----------

--- a/otbenchmark/_ReliabilityProblem57.py
+++ b/otbenchmark/_ReliabilityProblem57.py
@@ -11,20 +11,30 @@ import openturns as ot
 
 class ReliabilityProblem57(ReliabilityBenchmarkProblem):
     def __init__(self, threshold=0.0, mu=[0.0] * 2, sigma=[1.0] * 2):
-        """
+        r"""
         Creates a reliability problem RP57.
 
-        The event is {g(X) < threshold} where
+        The event is :math:`\{g(\boldsymbol{X}) < \text{threshold}\}` where:
 
-        g(x1, x2) = min(max(g1, g2), g3) with
+        .. math::
+          g(\boldsymbol{x}) = \min(\max(g_1(\boldsymbol{x}), g_2(\boldsymbol{x})),
+            g_3(\boldsymbol{x}))
 
-        g1 = -x1^2 + x2^3 + 3
+        for any :math:`\boldsymbol{x} \in \mathbb{R}^2`
+        with:
 
-        g2 = 2 - x1 - 8 * x2
+        .. math::
 
-        g3 = (x1 + 3)^2 + (x2 + 3)^2 - 4
+          g_1(\boldsymbol{x}) &= -x_1^2 + x_2^3 + 3
 
-        We have x1 ~ Normal(mu[0], sigma[0]) and x2 ~ Normal(mu[1], sigma[1]).
+          g_2(\boldsymbol{x}) &= 2 - x_1 - 8 x_2
+
+          g_3(\boldsymbol{x}) &= (x_1 + 3)^2 + (x_2 + 3)^2 - 4
+
+        We have:
+
+        * x1 ~ Normal(mu[0], sigma[0]) and
+        * x2 ~ Normal(mu[1], sigma[1]).
 
         Parameters
         ----------

--- a/otbenchmark/_ReliabilityProblem60.py
+++ b/otbenchmark/_ReliabilityProblem60.py
@@ -25,47 +25,49 @@ class ReliabilityProblem60(ReliabilityBenchmarkProblem):
         mu5=1200,
         sigma5=480,
     ):
-        """
+        r"""
         Creates a reliability problem RP60.
 
-        The event is {g(X) < threshold} with:
+        The event is :math:`\{g(\boldsymbol{X}) < \text{threshold}\}` with:
 
-            X = (x1, x2, x3, x4, x5)
+        .. math::
 
-            g1 = x1 - x5
+            g(\boldsymbol{x}) = \min(g_1(\boldsymbol{x}), g_{11}(\boldsymbol{x}))
 
-            g2 = x2 - x5 / 2
+        for any :math:`\boldsymbol{x} \in \mathbb{R}^{5}` where:
 
-            g3 = x3 - x5 / 2
+        .. math::
 
-            g4 = x4 - x5 / 2
+            g_1(\boldsymbol{x}) &= x_1 - x_5
 
-            g5 = x2 - x5
+            g_2(\boldsymbol{x}) &= x_2 - \frac{x_5}{2}
 
-            g6 = x3 - x5
+            g_3(\boldsymbol{x}) &= x_3 - \frac{x_5}{2}
 
-            g7 = x4 - x5
+            g_4(\boldsymbol{x}) &= x_4 - \frac{x_5}{2}
 
-            g8 = min(g5, g6)
+            g_5(\boldsymbol{x}) &= x_2 - x_5
 
-            g9 = max(g7, g8)
+            g_6(\boldsymbol{x}) &= x_3 - x_5
 
-            g10 = min(g2, g3, g4)
+            g_7(\boldsymbol{x}) &= x_4 - x_5
 
-            g11 = max(g10, g9)
+            g_8(\boldsymbol{x}) &= \min(g_5(\boldsymbol{x}), g_6(\boldsymbol{x}))
 
-            g(X) = min(g1, g11)
+            g_9(\boldsymbol{x}) &= \max(g_7(\boldsymbol{x}), g_8(\boldsymbol{x}))
+
+            g_{10}(\boldsymbol{x}) &= \min(g_2(\boldsymbol{x}), g_3(\boldsymbol{x}), g_4(\boldsymbol{x}))
+
+            g_{11}(\boldsymbol{x}) &= \max(g_{10}(\boldsymbol{x}), g_9(\boldsymbol{x}))
+
 
         We have :
-            x1 ~ LogNormalMuSigma(mu1, sigma1)
 
-            x2 ~ LogNormalMuSigma(mu2, sigma2)
-
-            x3 ~ LogNormalMuSigma(mu3, sigma3)
-
-            x4 ~ LogNormalMuSigma(mu4, sigma4)
-
-            x5 ~ LogNormalMuSigma(mu5, sigma5)
+        * x1 ~ LogNormalMuSigma(mu1, sigma1),
+        * x2 ~ LogNormalMuSigma(mu2, sigma2),
+        * x3 ~ LogNormalMuSigma(mu3, sigma3),
+        * x4 ~ LogNormalMuSigma(mu4, sigma4),
+        * x5 ~ LogNormalMuSigma(mu5, sigma5).
 
         Parameters
         ----------

--- a/otbenchmark/_ReliabilityProblem63.py
+++ b/otbenchmark/_ReliabilityProblem63.py
@@ -12,16 +12,24 @@ import openturns as ot
 
 class ReliabilityProblem63(ReliabilityBenchmarkProblem):
     def __init__(self, threshold=0.0, mu=0, sigma=1):
-        """
+        r"""
         Creates a reliability problem RP63.
 
-        The event is {g(X) < threshold} where
+        The event is :math:`\{g(\boldsymbol{X}) < \text{threshold}\}` where
 
-        X = (x1, x2, ...., x100)
+        .. math::
 
-        g(X) = 0.1 * (x2^2 + x3^2 + .... + x99^2 + x100^2) - x1 - 4.5
+            g(\boldsymbol{x}) = 0.1 \left(x_2^2 + x_3^2 + .... + x_{99}^2 + x_{100}^2\right) - x_1 - 4.5
 
-        We have xi ~ Normal(0, 1) for i in {1, 2, ...,100}
+        for any :math:`\boldsymbol{x} \in \mathbb{R}^{10}`.
+
+        We have:
+
+        .. math::
+
+            X_i \sim \mathcal{N}(0, 1)
+
+        for :math:`i \in \{1, 2, ...,100\}`.
 
         Parameters
         ----------

--- a/otbenchmark/_ReliabilityProblem75.py
+++ b/otbenchmark/_ReliabilityProblem75.py
@@ -11,14 +11,20 @@ import openturns as ot
 
 class ReliabilityProblem75(ReliabilityBenchmarkProblem):
     def __init__(self, threshold=0.0, mu=[0.0] * 2, sigma=[1.0] * 2):
-        """
+        r"""
         Creates a reliability problem RP75.
 
-        The event is {g(X) < threshold} where
+        The event is :math:`\{g(\boldsymbol{X}) < \text{threshold}\}` where
 
-        g(x1, x2) = 3 - x1 * x2
+        .. math::
 
-        We have x1 ~ Normal(mu[0], sigma[0]) and x2 ~ Normal(mu[1], sigma[1]).
+          g(x_1, x_2) = 3 - x_1 x_2
+
+        for any :math:`\boldsymbol{x} \in \mathbb{R}^2`.
+        We have:
+
+        * x1 ~ Normal(mu[0], sigma[0]) and
+        * x2 ~ Normal(mu[1], sigma[1]).
 
         Parameters
         ----------

--- a/otbenchmark/_ReliabilityProblem77.py
+++ b/otbenchmark/_ReliabilityProblem77.py
@@ -21,25 +21,25 @@ class ReliabilityProblem77(ReliabilityBenchmarkProblem):
         mu3=4.0,
         sigma3=1.0,
     ):
-        """
+        r"""
         Creates a reliability problem RP77.
 
-        The event is {g(X) < threshold} where
+        The event is :math:`\{g(\boldsymbol{X}) < \text{threshold}\}` where
 
-        X = (x1, x2, x3)
+        .. math::
+            g(\boldsymbol{x}) =
+            \begin{cases}
+            x_1 - x_2 - x_3 & \text{ if } x_3 \leq 5.0, \\
+            x_3 - x_2 & \text{otherwise},
+            \end{cases}
 
-        if (x3 <= 5.0):
-            g(x1, x2, x3) = x1 - x2 - x3
-
-        else :
-            g(x1, x2, x3) = x3 - x2
-
+        for any :math:`\boldsymbol{x} \in \mathbb{R}^{3}`.
         We have :
-            x1 ~ Normal(mu1, sigma1)
 
-            x2 ~ Normal(mu2, sigma2)
-
-            x3 ~ Normal(mu3, sigma3)
+        .. math::
+            & X_1 \sim \mathcal{N}(\mu_1, \sigma_1^2), \\
+            & X_2 \sim \mathcal{N}(\mu_2, \sigma_2^2), \\
+            & X_3 \sim \mathcal{N}(\mu_3, \sigma_3^2).
 
         Parameters
         ----------
@@ -59,11 +59,7 @@ class ReliabilityProblem77(ReliabilityBenchmarkProblem):
             The standard deviation of the X3 gaussian distribution.
         """
         equations = [
-            "if (x3 <= 5.0)",
-            "var g1 := x1 - x2 - x3;",
-            "else",
-            "  g1 := x3 - x2;",
-            "gsys := g1;",
+            "gsys := (x3 <= 5.0) ? x1 - x2 - x3 : x3 - x2;",
         ]
         program = "\n".join(equations)
 

--- a/otbenchmark/_ReliabilityProblem8.py
+++ b/otbenchmark/_ReliabilityProblem8.py
@@ -27,27 +27,25 @@ class ReliabilityProblem8(ReliabilityBenchmarkProblem):
         mu6=40.0,
         sigma6=8.0,
     ):
-        """
+        r"""
         Creates a reliability problem RP8.
 
-        The event is {g(X) < threshold} where
+        The event is :math:`\{g(\boldsymbol{X}) < \text{threshold}\}` where:
 
-        X = (x1, x2, x3, x4, x5, x6)
+        .. math::
 
-        g(X) = x1 + 2 * x2 + 2 * x3 + x4 - 5 * x5 - 5 * x6
+            g(\boldsymbol{x}) = x_1 + 2 x_2 + 2 x_3 + x_4 - 5 x_5 - 5 x_6
+
+        for any :math:`\boldsymbol{x} \in \mathbb{R}^6`.
 
         We have :
-            x1 ~ LogNormalMuSigma(mu1, sigma1)
 
-            x2 ~ LogNormalMuSigma(mu2, sigma2)
-
-            x3 ~ LogNormalMuSigma(mu3, sigma3)
-
-            x4 ~ LogNormalMuSigma(mu4, sigma4)
-
-            x5 ~ LogNormalMuSigma(mu5, sigma5)
-
-            x6 ~ LogNormalMuSigma(mu6, sigma6)
+        * x1 ~ LogNormalMuSigma(mu1, sigma1),
+        * x2 ~ LogNormalMuSigma(mu2, sigma2),
+        * x3 ~ LogNormalMuSigma(mu3, sigma3),
+        * x4 ~ LogNormalMuSigma(mu4, sigma4),
+        * x5 ~ LogNormalMuSigma(mu5, sigma5),
+        * x6 ~ LogNormalMuSigma(mu6, sigma6).
 
         Parameters
         ----------

--- a/otbenchmark/_ReliabilityProblem89.py
+++ b/otbenchmark/_ReliabilityProblem89.py
@@ -12,14 +12,20 @@ import openturns as ot
 
 class ReliabilityProblem89(ReliabilityBenchmarkProblem):
     def __init__(self, threshold=0.0, mu=[0.0] * 2, sigma=[1.0] * 2):
-        """
+        r"""
         Creates a reliability problem RP89.
 
-        The event is {g(X) < threshold} where
+        The event is :math:`\{g(\boldsymbol{X}) < \text{threshold}\}` where:
 
-        g(x1, x2) = min(-x1^2 - x2 + 8, -x1 / 5 - x2 + 6)
+        .. math::
 
-        We have x1 ~ Normal(mu[0], sigma[0]) and x2 ~ Normal(mu[1], sigma[1]).
+            g(x_1, x_2) = \min(-x_1^2 - x_2 + 8, -x_1 / 5 - x_2 + 6)
+
+        for any :math:`\boldsymbol{x} \in \mathbb{R}^2`.
+        We have:
+
+        * x1 ~ Normal(mu[0], sigma[0]) and
+        * x2 ~ Normal(mu[1], sigma[1]).
 
         Parameters
         ----------

--- a/otbenchmark/_ReliabilityProblem91.py
+++ b/otbenchmark/_ReliabilityProblem91.py
@@ -25,32 +25,36 @@ class ReliabilityProblem91(ReliabilityBenchmarkProblem):
         mu5=-684.0,
         sigma5=11.0,
     ):
-        """
+        r"""
         Creates a reliability problem RP91.
 
-        The event is {g(X) < threshold} where
+        The event is :math:`\{g(\boldsymbol{X}) < \text{threshold}\}` where
 
-        X = (x1, x2, x3, x4, x5)
+        .. math::
 
-        g1 = 0.847 + 0.96 * x2 + 0.986 * x3- 0.216 * x4 + 0.077 * x2^2 + 0.11
-        * x3^2 + (7 / 378) * x4^2- x3 * x2 - 0.106 * x2 * x4 - 0.11 * x3 * x4
+            g(\boldsymbol{x}) = \min(g_1(\boldsymbol{x}), g_2(\boldsymbol{x}),
+                g_3(\boldsymbol{x}))
 
-        g2 = 84000 * x1 / sqrt(x3^2 + x4^2 - x3 * x4 + 3 * x5^2) - 1
+        for any :math:`\boldsymbol{x} \in \mathbb{R}^{5}`.
 
-        g3 = 84000 * x1 / abs(x4) - 1
+        .. math::
 
-        g(X) = min(g1, g2, g3)
+            g_1(\boldsymbol{x}) & = 0.847 + 0.96 x_2 + 0.986 x_3 - 0.216 x_4 \\
+                &\quad + 0.077 x_2^2 + 0.11 x_3^2 + \frac{7}{378} x_4^2 \\
+                &\quad - x_3 x_2 - 0.106 x_2 x_4 - 0.11 x_3 x_4
+
+            g_2(\boldsymbol{x}) & = \frac{84000 x_1}{\sqrt{x_3^2 + x_4^2 - x_3 x_4 + 3 x_5^2}} - 1
+
+            g_3(\boldsymbol{x}) & = \frac{84000 x_1}{|x_4|} - 1
+
 
         We have :
-            x1 ~ Normal(mu1, sigma1)
 
-            x2 ~ Normal(mu2, sigma2)
-
-            x3 ~ Normal(mu3, sigma3)
-
-            x4 ~ Normal(mu4, sigma4)
-
-            x5 ~ Normal(mu5, sigma5)
+        * x1 ~ Normal(mu1, sigma1),
+        * x2 ~ Normal(mu2, sigma2),
+        * x3 ~ Normal(mu3, sigma3),
+        * x4 ~ Normal(mu4, sigma4),
+        * x5 ~ Normal(mu5, sigma5).
 
         Parameters
         ----------

--- a/otbenchmark/_RminusSReliability.py
+++ b/otbenchmark/_RminusSReliability.py
@@ -6,12 +6,14 @@ import openturns as ot
 
 class RminusSReliability(ReliabilityBenchmarkProblem):
     def __init__(self, threshold=0.0, muR=4.0, sigmaR=1.0, muS=2.0, sigmaS=1.0):
-        """
+        r"""
         Create a R-S reliability problem.
 
-        The event is {g(X) < threshold} where
+        The event is :math:`\{g(\boldsymbol{X}) < \text{threshold}\}` where:
 
-        g(R, S) = R - S
+        .. math::
+
+            g(R, S) = R - S
 
         We have R ~ Normal(muR, sigmaR) and S ~ Normal(muS, sigmaS).
 

--- a/otbenchmark/_SensitivityBenchmarkMetaAlgorithm.py
+++ b/otbenchmark/_SensitivityBenchmarkMetaAlgorithm.py
@@ -1,6 +1,7 @@
 """
 Manage sensitivity problems.
 """
+
 import openturns as ot
 import otbenchmark as otb
 
@@ -12,6 +13,7 @@ class SensitivityBenchmarkMetaAlgorithm:
         Get the available sample-based estimators.
 
         This currently involves four estimators:
+
         * ot.SaltelliSensitivityAlgorithm
         * ot.MartinezSensitivityAlgorithm
         * ot.JansenSensitivityAlgorithm
@@ -56,8 +58,8 @@ class SensitivityBenchmarkMetaAlgorithm:
         Runs the sampling sensitivity estimator and get the results.
 
         We may let the user select the estimator by taking
-        e.g. the SaltelliSensitivityAlgorithm() as input argument,
-        and use setDesign(), but this currently fails:
+        e.g. the :class:`ot.SaltelliSensitivityAlgorithm` as input argument,
+        and use :meth:`ot.SaltelliSensitivityAlgorithm.setDesign`, but this currently fails:
         https://github.com/openturns/openturns/issues/1884
         This is why the estimator input argument is currently a string.
 

--- a/otbenchmark/_SensitivityConvergence.py
+++ b/otbenchmark/_SensitivityConvergence.py
@@ -1,6 +1,7 @@
 """
 Perform a convergence study of a sensitivity analysis estimator.
 """
+
 import openturns as ot
 import numpy as np
 import time
@@ -94,7 +95,7 @@ class SensitivityConvergence:
         return None
 
     def computeError(self, sample_size):
-        """
+        r"""
         Compute the absolute error for the problem with Monte-Carlo sample.
 
         Uses Saltelli estimator.
@@ -104,9 +105,12 @@ class SensitivityConvergence:
         We compute the absolute error between the reference Sobol'
         indices and the computed Sobol' indices:
 
-            AE(i) = abs(S_computed(i) - S_reference(i))
+        .. math::
 
-        for i = 1, ..., p where p is the dimension of the problem.
+            \text{AE}_i = \left|S_{\text{computed},i} - S_{\text{reference}, i}\right|
+
+        for :math:`i \in \{1, ..., \inputDim\}` where :math:`\inputDim` is the
+        dimension of the problem.
 
         Parameters
         ----------

--- a/otbenchmark/__init__.py
+++ b/otbenchmark/__init__.py
@@ -37,7 +37,9 @@ from .SensitivityLibrary import SensitivityBenchmarkProblemList
 from ._FORM import FORM
 from ._SORM import SORM
 from ._SubsetSampling import SubsetSampling
-from ._ProbabilitySimulationAlgorithmFactory import ProbabilitySimulationAlgorithmFactory
+from ._ProbabilitySimulationAlgorithmFactory import (
+    ProbabilitySimulationAlgorithmFactory,
+)
 from ._LHS import LHS
 from ._ReliabilityBenchmarkMetaAlgorithm import ReliabilityBenchmarkMetaAlgorithm
 from ._ReliabilityBenchmarkResult import ReliabilityBenchmarkResult


### PR DESCRIPTION
- Fixed enumerate list in doc/examples/sensitivity_methods/plot_benchmark_sensitivity_methods.py.

<img width="1146" height="242" alt="image" src="https://github.com/user-attachments/assets/441b71f2-e5a1-477f-b7dd-e363ed5f172c" />

- Added an example into the README, so that the user can known what the package is about.
- Created an example to show how to create a new reliability benchmark problem.
- Fixed LaTeX equations of sensitivity problems.
- Used Black on Python scripts.
- Updated formula for OpenTURNS 1.26, for reliability problems using ExprTk.